### PR TITLE
Make buttons slightly more prominient

### DIFF
--- a/docs/css/pariyatti.css
+++ b/docs/css/pariyatti.css
@@ -16,8 +16,8 @@
 }
 
 .store-buttons img {
-  width: 136px;
-  height: 40px;  
+  width: 200px;
+  height: auto;  
   margin-left: 11px;
   margin-right: 11px;
 }


### PR DESCRIPTION
The app store buttons are slightly small have to zoom on the phone to click on them.
![Screenshot_2022-07-30-14-53-14-74_40deb401b9ffe8e1df2f1cc5ba480b12](https://user-images.githubusercontent.com/4284516/181904288-c95cde4b-0591-40f6-9d7a-f270d1e51ca4.jpg)

